### PR TITLE
Update Machine learning - TD1.ipynb

### DIFF
--- a/Machine learning/Machine learning - TD1.ipynb
+++ b/Machine learning/Machine learning - TD1.ipynb
@@ -1863,7 +1863,7 @@
     "                                actual_movie_ratings_list),\n",
     "     \"np\": evalmae_np(predicted_movie_ratings_array,\n",
     "                      actual_movie_ratings_array),\n",
-    "     \"sklearn\": evalmae_np(predicted_movie_ratings_array,\n",
+    "     \"sklearn\": evalmae_sklearn(predicted_movie_ratings_array,\n",
     "                           actual_movie_ratings_array)}\n",
     "}"
    ]
@@ -1940,7 +1940,7 @@
     "                                actual_movie_ratings_list),\n",
     "     \"np\": evalmae_np(predicted_movie_ratings_array,\n",
     "                      actual_movie_ratings_array),\n",
-    "     \"sklearn\": evalmae_np(predicted_movie_ratings_array,\n",
+    "     \"sklearn\": evalmae_sklearn(predicted_movie_ratings_array,\n",
     "                           actual_movie_ratings_array)}\n",
     "}"
    ]
@@ -2033,7 +2033,7 @@
     "                                actual_movie_ratings_list),\n",
     "     \"np\": evalmae_np(predicted_movie_ratings_array,\n",
     "                      actual_movie_ratings_array),\n",
-    "     \"sklearn\": evalmae_np(predicted_movie_ratings_array,\n",
+    "     \"sklearn\": evalmae_sklearn(predicted_movie_ratings_array,\n",
     "                           actual_movie_ratings_array)}\n",
     "}"
    ]


### PR DESCRIPTION
Typo issue fixed in subsection 0.8 -> in the dictionnaries, the entries "evalmae_sklearn" were actually evalmae_np.